### PR TITLE
Change the target name for "fermat"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,13 @@ file(GLOB SOURCES src/*.cpp)
 file(GLOB TOOL_SOURCES tool/*.cpp)
 
 add_library(Fermat SHARED ${SOURCES})
-add_executable(fermat ${TOOL_SOURCES})
-target_link_libraries(fermat Fermat)
+add_executable(fermat_exe ${TOOL_SOURCES})
+target_link_libraries(fermat_exe Fermat)
+set_target_properties(fermat_exe PROPERTIES OUTPUT_NAME fermat)
 
 install (DIRECTORY include/ pstreams/ DESTINATION "${INSTALL_INCLUDE_DIR}" FILES_MATCHING PATTERN "*.h")
 install (TARGETS Fermat EXPORT libFermatTargets DESTINATION "${INSTALL_LIB_DIR}")
-install (TARGETS fermat DESTINATION bin)
+install (TARGETS fermat_exe DESTINATION bin)
 
 file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")
 file(RELATIVE_PATH REL_LIBRARY_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_LIB_DIR}")


### PR DESCRIPTION
The two target names `fermat` and `Fermat` have a problem with CMake on case-insensitive file systems, for example, HFS+ of Apple by default. This causes a build error as reported in tueda/homebrew-loops#2.

This patch change the target `fermat` to `fermat_exe` but the binary file is renamed to `fermat` on the installation.